### PR TITLE
Test and fix cases with nested contexts

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -55,10 +55,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				break
 			}
 
+			// allow assignment to non-pointer children of values defined within the loop
 			if lhs := getRootIdent(pass, assignStmt.Lhs[0]); lhs != nil {
 				if obj := pass.TypesInfo.ObjectOf(lhs); obj != nil {
 					if obj.Pos() >= body.Pos() && obj.Pos() < body.End() {
-						continue
+						continue // definition is within the loop
 					}
 				}
 			}

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -59,9 +59,15 @@ func inStructs(ctx context.Context) {
 		c.Ctx = context.WithValue(c.Ctx, "other", "val")
 	}
 
+	r := []struct{ Ctx context.Context }{{ctx}}
 	for i := 0; i < 10; i++ {
-		c := []*struct{ Ctx context.Context }{{ctx}}
-		c[0].Ctx = context.WithValue(c[0].Ctx, "key", i) // want "nested context in loop"
-		c[0].Ctx = context.WithValue(c[0].Ctx, "other", "val")
+		r[0].Ctx = context.WithValue(r[0].Ctx, "key", i) // want "nested context in loop"
+		r[0].Ctx = context.WithValue(r[0].Ctx, "other", "val")
+	}
+
+	rp := []*struct{ Ctx context.Context }{{ctx}}
+	for i := 0; i < 10; i++ {
+		rp[0].Ctx = context.WithValue(rp[0].Ctx, "key", i) // want "nested context in loop"
+		rp[0].Ctx = context.WithValue(rp[0].Ctx, "other", "val")
 	}
 }

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -30,3 +30,38 @@ func example() {
 func wrapContext(ctx context.Context) context.Context {
 	return context.WithoutCancel(ctx)
 }
+
+// storing contexts in a struct isn't recommended, but local copies of a non-pointer struct should act like local copies of a context.
+func inStructs(ctx context.Context) {
+	for i := 0; i < 10; i++ {
+		c := struct{ Ctx context.Context }{ctx}
+		c.Ctx = context.WithValue(c.Ctx, "key", i)
+		c.Ctx = context.WithValue(c.Ctx, "other", "val")
+	}
+
+	for i := 0; i < 10; i++ {
+		c := []struct{ Ctx context.Context }{{ctx}}
+		c[0].Ctx = context.WithValue(c[0].Ctx, "key", i)
+		c[0].Ctx = context.WithValue(c[0].Ctx, "other", "val")
+	}
+
+	c := struct{ Ctx context.Context }{ctx}
+	for i := 0; i < 10; i++ {
+		c := c
+		c.Ctx = context.WithValue(c.Ctx, "key", i)
+		c.Ctx = context.WithValue(c.Ctx, "other", "val")
+	}
+
+	pc := &struct{ Ctx context.Context }{ctx}
+	for i := 0; i < 10; i++ {
+		c := pc
+		c.Ctx = context.WithValue(c.Ctx, "key", i) // want "nested context in loop"
+		c.Ctx = context.WithValue(c.Ctx, "other", "val")
+	}
+
+	for i := 0; i < 10; i++ {
+		c := []*struct{ Ctx context.Context }{{ctx}}
+		c[0].Ctx = context.WithValue(c[0].Ctx, "key", i) // want "nested context in loop"
+		c[0].Ctx = context.WithValue(c[0].Ctx, "other", "val")
+	}
+}


### PR DESCRIPTION
As long as the context is rooted in a non-pointer value that has a new copy in the loop, it is as safe to copy that value as it is to copy the context. So only report such cases when they are indirected and thus shared.

Fixes #8