### PR TITLE
Adding support for detecting nested contexts in function literals

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -110,21 +110,21 @@ func findNestedContext(pass *analysis.Pass, node ast.Node, stmts []ast.Stmt) *as
 	for _, stmt := range stmts {
 		// Recurse if necessary
 		if inner, ok := stmt.(*ast.BlockStmt); ok {
-			found := findNestedContext(pass, inner, inner.List)
+			found := findNestedContext(pass, node, inner.List)
 			if found != nil {
 				return found
 			}
 		}
 
 		if inner, ok := stmt.(*ast.IfStmt); ok {
-			found := findNestedContext(pass, inner, inner.Body.List)
+			found := findNestedContext(pass, node, inner.Body.List)
 			if found != nil {
 				return found
 			}
 		}
 
 		if inner, ok := stmt.(*ast.SwitchStmt); ok {
-			found := findNestedContext(pass, inner, inner.Body.List)
+			found := findNestedContext(pass, node, inner.Body.List)
 			if found != nil {
 				return found
 			}
@@ -138,7 +138,7 @@ func findNestedContext(pass *analysis.Pass, node ast.Node, stmts []ast.Stmt) *as
 		}
 
 		if inner, ok := stmt.(*ast.SelectStmt); ok {
-			found := findNestedContext(pass, inner, inner.Body.List)
+			found := findNestedContext(pass, node, inner.Body.List)
 			if found != nil {
 				return found
 			}
@@ -167,7 +167,7 @@ func findNestedContext(pass *analysis.Pass, node ast.Node, stmts []ast.Stmt) *as
 		}
 
 		if assignStmt.Tok == token.DEFINE {
-			break
+			continue
 		}
 
 		// allow assignment to non-pointer children of values defined within the loop

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -78,9 +78,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 func getReportMessage(node ast.Node) string {
 	switch node.(type) {
-	case *ast.ForStmt:
-		return "nested context in loop"
-	case *ast.RangeStmt:
+	case *ast.ForStmt, *ast.RangeStmt:
 		return "nested context in loop"
 	case *ast.FuncLit:
 		return "nested context in function literal"

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -85,7 +85,7 @@ func getReportMessage(node ast.Node) string {
 	case *ast.FuncLit:
 		return "nested context in function literal"
 	default:
-		return "nested context"
+		return "unsupported nested context type"
 	}
 }
 

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -71,6 +71,14 @@ func example() {
 			ctx = wrapContext(ctx)
 		}
 	}
+
+	for {
+		ctx2 := context.Background()
+		ctx = wrapContext(ctx) // want "nested context in loop"
+		if doSomething() != nil {
+			ctx2 = wrapContext(ctx2)
+		}
+	}
 }
 
 func wrapContext(ctx context.Context) context.Context {

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -65,6 +65,12 @@ func example() {
 		ctx = wrapContext(ctx) // want "nested context in function literal"
 	}
 
+	// this is fine because the context is created in the loop
+	for {
+		if ctx := context.Background(); doSomething() != nil {
+			ctx = wrapContext(ctx)
+		}
+	}
 }
 
 func wrapContext(ctx context.Context) context.Context {

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -188,9 +188,29 @@ func inVariousNestedBlocks(ctx context.Context) {
 }
 
 // this middleware could run on every request, bloating the request parameter level context and causing a memory leak
-func memoryLeakCausingMiddleware(ctx context.Context) func(ctx context.Context) error {
-	return func(ctx context.Context) error {
+func badMiddleware(ctx context.Context) func() error {
+	return func() error {
 		ctx = wrapContext(ctx) // want "nested context in function literal"
-		return doSomething()
+		return doSomethingWithCtx(ctx)
 	}
+}
+
+// this middleware is fine, as it doesn't modify the context of parent function
+func okMiddleware(ctx context.Context) func() error {
+	return func() error {
+		ctx := wrapContext(ctx)
+		return doSomethingWithCtx(ctx)
+	}
+}
+
+// this middleware is fine, as it only modifies the context passed to it
+func okMiddleware2(ctx context.Context) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		ctx = wrapContext(ctx)
+		return doSomethingWithCtx(ctx)
+	}
+}
+
+func doSomethingWithCtx(ctx context.Context) error {
+	return nil
 }

--- a/testdata/src/example.go
+++ b/testdata/src/example.go
@@ -59,6 +59,12 @@ func example() {
 
 		break
 	}
+
+	// detects contexts wrapped in function literals (this is risky as function literals can be called multiple times)
+	_ = func() {
+		ctx = wrapContext(ctx) // want "nested context in function literal"
+	}
+
 }
 
 func wrapContext(ctx context.Context) context.Context {
@@ -178,5 +184,13 @@ func inVariousNestedBlocks(ctx context.Context) {
 		}
 
 		break
+	}
+}
+
+// this middleware could run on every request, bloating the request parameter level context and causing a memory leak
+func memoryLeakCausingMiddleware(ctx context.Context) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		ctx = wrapContext(ctx) // want "nested context in function literal"
+		return doSomething()
 	}
 }


### PR DESCRIPTION
Function literals are usually called multiple times during their lifetime (consider middlewares, mapping functions etc). If they are modifying a context variable that was defined out of their scope - maybe in the parent function- it can very quickly bloat the original context variable. This can cause memory leak. I have experienced the same while working with golan with at my day job. 

I think this change will help catch many such bugs. 

I have also added testcases for this and have improved the identifier scope checking logic.