### PR TITLE
fix: use min go1.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 
+/fatcontext
 dist/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Crocmagnon/fatcontext
 
-go 1.22.6
+go 1.22.0
 
 require golang.org/x/tools v0.23.0
 


### PR DESCRIPTION
As the linter is used as a lib it is better not to use a patched version.

Golangci-lint can be used with the "tools pattern", so it's better if we don't force the usage of a specific patched version if possible.


Related to https://github.com/golangci/golangci-lint/pull/4970
