### PR TITLE
chore: format with goimports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,9 @@
 issues:
   exclude-dirs:
     - contrib
+linters:
+  enable:
+    - goimports
+linters-settings:
+  goimports:
+    local-prefixes: "github.com/Crocmagnon/fatcontext"

--- a/cmd/fatcontext/main.go
+++ b/cmd/fatcontext/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
 	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
 )
 
 func main() {

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -1,11 +1,13 @@
 package analyzer_test
 
 import (
-	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
-	"golang.org/x/tools/go/analysis/analysistest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/Crocmagnon/fatcontext/pkg/analyzer"
 )
 
 func TestAll(t *testing.T) {


### PR DESCRIPTION
This PR sorts imports by running the command `goimports -w .`